### PR TITLE
docs: update README to use python3 for hello.py (fix #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ This is a simple test repository.
 To run the sample script:
 
 ```bash
-python hello.py
+python3 hello.py
 ```


### PR DESCRIPTION
This PR updates the README usage instructions to use `python3 hello.py` instead of `python hello.py`, as the script uses Python 3 syntax and may fail on systems where `python` points to Python 2. This addresses Issue #5.
close #5 